### PR TITLE
docs: sync skill repo with current workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [中文说明](./README.zh-CN.md)
 
-OpenClaw skill for the **X/Twitter → structured data → Xiaohongshu draft → dashboard** workflow.
+OpenClaw skill for the **X/Twitter → structured data → Xiaohongshu draft → review → publish-ready → publish-record → dashboard** workflow.
 
 This repository is the **skill / runbook layer**.
 It defines how an agent should operate the workflow, verify results, and hand off to the implementation project.
@@ -18,8 +18,9 @@ It defines how an agent should operate the workflow, verify results, and hand of
 - Keep the latest N posts per account with `replace_latest` dedupe
 - Rebuild or inspect the local operations dashboard
 - Generate a Xiaohongshu note draft from a bundle of multiple X posts
-- Show generated drafts inside the dashboard
-- Maintain the full X → normalized posts → note draft → dashboard pipeline
+- Review drafts inside the writable dashboard
+- Generate publish-ready payloads and record published results
+- Maintain the full X → normalized posts → note draft → review → publish traceability pipeline
 
 ## What's inside this repo
 
@@ -30,41 +31,69 @@ It defines how an agent should operate the workflow, verify results, and hand of
 ## Implementation project used by this skill
 
 - GitHub: `https://github.com/xiangbaqiu/xiaohongshu-yunying-laizi-x-xingqiu`
-- Local default path: `/Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu`
+- Local default path: `/Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu`
 
 ## Main commands
 
 ### Collect
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/auto_collect.js collect.config.json
 ```
 
 ### Generate note draft
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/run_note_pipeline.js note.config.json
 ```
 
 ### Rebuild dashboard
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node scripts/build_dashboard_data.js
 ```
 
-### Open dashboard
+### Open read-only dashboard
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 python3 -m http.server 8008
 ```
 
 Then open:
 
 `http://127.0.0.1:8008/dashboard/index.html`
+
+### Open writable dashboard
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/dashboard_server.js
+```
+
+Use writable mode when the operator needs to:
+
+- update review status
+- add review annotations
+- generate publish-ready payloads
+- record published results
+
+### Generate publish-ready payload
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/create_publish_ready.js <draft_id> --prepared-by xiangbaqiu
+```
+
+### Record published result
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/record_publish_result.js <draft_id> --published-by xiangbaqiu --platform-url https://www.xiaohongshu.com/explore/<note_id>
+```
 
 ## Notes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # xiaohongshu-x-planet
 
-用于运行 **X/Twitter → 结构化数据 → 小红书草稿 → dashboard** 工作流的 OpenClaw Skill。
+用于运行 **X/Twitter → 结构化数据 → 小红书草稿 → review → publish-ready → publish-record → dashboard** 工作流的 OpenClaw Skill。
 
 这个仓库是 **skill / runbook 层**。
 它定义了 agent 应该如何操作这条工作流、如何校验结果，以及如何与实现项目协同工作。
@@ -16,8 +16,9 @@
 - 按 `replace_latest` 模式保留每个账号最新 N 条内容
 - 重建或检查本地运营 dashboard
 - 基于多条 X 内容生成一篇小红书草稿
-- 在 dashboard 中展示生成草稿
-- 维护整条 X → 标准化内容 → 草稿 → dashboard 的工作流
+- 在可写 dashboard 中做审核和批注
+- 生成 publish-ready payload，并记录 published 结果
+- 维护整条 X → 标准化内容 → 草稿 → 审核 → 发布追踪 的工作流
 
 ## 仓库内容
 
@@ -28,41 +29,69 @@
 ## 这个 skill 依赖的实现项目
 
 - GitHub：`https://github.com/xiangbaqiu/xiaohongshu-yunying-laizi-x-xingqiu`
-- 本地默认路径：`/Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu`
+- 本地默认路径：`/Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu`
 
 ## 主要命令
 
 ### 采集账号内容
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/auto_collect.js collect.config.json
 ```
 
 ### 生成小红书草稿
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/run_note_pipeline.js note.config.json
 ```
 
 ### 重建 dashboard 数据
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node scripts/build_dashboard_data.js
 ```
 
-### 打开 dashboard
+### 打开只读 dashboard
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 python3 -m http.server 8008
 ```
 
 然后访问：
 
 `http://127.0.0.1:8008/dashboard/index.html`
+
+### 打开可写 dashboard
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/dashboard_server.js
+```
+
+可写模式适合做这些事：
+
+- 更新审核状态
+- 记录审核批注
+- 生成 publish-ready payload
+- 记录真实发布结果
+
+### 生成 publish-ready payload
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/create_publish_ready.js <draft_id> --prepared-by xiangbaqiu
+```
+
+### 记录 published 结果
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/record_publish_result.js <draft_id> --published-by xiangbaqiu --platform-url https://www.xiaohongshu.com/explore/<note_id>
+```
 
 ## 说明
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: xiaohongshu-x-planet
-description: Run the "小红书运营来自 X 星球" workflow as a gstack-style command runbook. Use when the user wants to: (1) collect one or more X/Twitter accounts, (2) keep the latest N posts per account with replace-latest dedupe, (3) rebuild or inspect the local operations dashboard, (4) generate a Xiaohongshu note draft from a bundle of multiple X posts, (5) show generated drafts inside the dashboard, or (6) maintain the full X → structured data → note draft → dashboard pipeline.
+description: Run the "小红书运营来自 X 星球" workflow as a gstack-style command runbook. Use when the user wants to: (1) collect one or more X/Twitter accounts, (2) keep the latest N posts per account with replace-latest dedupe, (3) rebuild or inspect the local operations dashboard, (4) generate a Xiaohongshu note draft from a bundle of multiple X posts, (5) review drafts in the writable dashboard, (6) generate publish-ready payloads, (7) record published results, or (8) maintain the full X → structured data → note draft → review → publish traceability pipeline.
 ---
 
 Use the implementation project at:
 
 - GitHub: `https://github.com/xiangbaqiu/xiaohongshu-yunying-laizi-x-xingqiu`
-- Local default path: `/Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu`
+- Local default path: `/Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu`
 
 # Runbook
 
@@ -31,7 +31,7 @@ Goal: collect multiple X accounts and keep the latest N posts per account.
 3. Run:
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/auto_collect.js collect.config.json
 ```
 
@@ -48,7 +48,7 @@ Goal: confirm the collector met the requested target.
 Run:
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 wc -l data/x/accounts/*/posts.jsonl
 cat data/x/accounts/<handle>/state.json
 ```
@@ -80,25 +80,27 @@ Goal: turn a bundle of multiple X posts into one Xiaohongshu draft.
 3. Run:
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/run_note_pipeline.js note.config.json
 ```
 
 4. Expect:
-   - `notes/selections/*.json`
+   - `notes/bundles/*.json`
    - `notes/briefs/*.json`
    - `notes/drafts/*.json`
    - `notes/drafts/*.md`
+   - `notes/runs/*.json`
 
 ## Command 4 — Verify note bundle
 
 Goal: confirm note generation used a post bundle, not a single post rewrite.
 
-Check the latest selection file. Expect:
+Check the latest bundle file. Expect:
 
 - `bundle.core_post`
 - `bundle.supporting_posts`
 - `bundle_strategy: one-core-plus-supporting-posts`
+- stable `bundle_id`
 
 Check the latest brief file. Expect:
 
@@ -113,7 +115,7 @@ Goal: refresh operator view without recollecting.
 Run:
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node scripts/build_dashboard_data.js
 ```
 
@@ -124,14 +126,14 @@ Use when:
 - note drafts changed
 - raw/account data already exists
 
-## Command 6 — Open dashboard
+## Command 6 — Open read-only dashboard
 
 Goal: visually verify operator-facing output.
 
 Run:
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 python3 -m http.server 8008
 ```
 
@@ -149,14 +151,67 @@ Check:
 - content type filter works
 - generated note drafts render in the `生成内容` panel
 
-## Command 7 — Rebuild from existing raw
+## Command 7 — Open writable dashboard
+
+Goal: run review and publish-traceability actions from the dashboard.
+
+Run:
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/dashboard_server.js
+```
+
+Use writable mode when the operator needs to:
+
+- move a draft into `reviewing`
+- mark `approved` / `needs_edit` / `rejected`
+- persist review annotations
+- generate publish-ready payloads
+- record published results
+
+## Command 8 — Generate publish-ready payload
+
+Goal: materialize a stable handoff artifact for an approved draft.
+
+Run:
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/create_publish_ready.js <draft_id> --prepared-by xiangbaqiu
+```
+
+Pass criteria:
+
+- only `approved` drafts succeed
+- `notes/publish-ready/<draft_id>.json` is written
+- the dashboard can show publish-ready traceability after rebuild
+
+## Command 9 — Record published result
+
+Goal: write a publish record and move a draft into `published`.
+
+Run:
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/record_publish_result.js <draft_id> --published-by xiangbaqiu --platform-url https://www.xiaohongshu.com/explore/<note_id>
+```
+
+Pass criteria:
+
+- `notes/publish-records/*.json` is written
+- source draft is updated to `review_status = published`
+- dashboard traceability shows publish time and external platform URL
+
+## Command 10 — Rebuild from existing raw
 
 Goal: rerun normalization without recollecting from X.
 
 Run:
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/run_from_raw.js samples/raw/<handle>-raw.json <handle>
 ```
 
@@ -173,6 +228,7 @@ Prefer these defaults unless the user says otherwise:
 - `mode: "replace_latest"`
 - dashboard default post filter: `original`
 - note generation uses multiple-post bundles, not single-post rewrite
+- review happens before publish-ready / publish-record steps
 - preserve raw batch files
 - preserve content typing fields
 
@@ -186,7 +242,9 @@ Do not break these guarantees:
 - replace-latest mode
 - dashboard rebuild after collection
 - generated drafts can be shown in dashboard
-- note selection remains bundle-based
+- note generation remains bundle-based
+- review status remains explicit and traceable in dashboard data
+- publish-ready / publish-record artifacts remain local-first and recoverable
 - content type values remain: `original | repost | quote | reply | unknown`
 
 # Operator schema
@@ -206,10 +264,14 @@ Keep these structures available in note generation outputs:
 
 - `bundle.core_post`
 - `bundle.supporting_posts`
+- `review_status`
+- `review_annotation`
 - `narrative_structure`
 - `title_options`
 - `body_markdown`
 - `source_posts`
+- `publish_ready`
+- `publish_record`
 
 # Escalation path
 

--- a/references/ops-rules.md
+++ b/references/ops-rules.md
@@ -8,6 +8,8 @@
 - Preserve raw batches so normalization can be re-run after rule changes
 - Generate note drafts from a post bundle, not from a single-post rewrite
 - Show generated drafts in dashboard when operators need review in one place
+- Prefer writable dashboard mode for review and publish-traceability actions
+- Treat publish-ready and publish-record as manual checkpoints, not hidden automation
 
 ## Safe change order
 
@@ -18,7 +20,8 @@ When evolving the system, prefer this order:
 3. Adjust note selection / brief / composition if needed
 4. Rebuild dashboard JSON
 5. Open dashboard for visual verification
-6. Commit changes
+6. Run review / publish-ready / publish-record actions if the task needs them
+7. Commit changes
 
 ## Common tasks
 
@@ -67,6 +70,32 @@ ls -1 notes/drafts
 ```
 
 or open dashboard and inspect the `生成内容` panel.
+
+### Open writable dashboard for review actions
+
+Run:
+
+```bash
+node scripts/dashboard_server.js
+```
+
+Use this mode when the operator needs to update review status, add annotations, generate publish-ready payloads, or record a published result.
+
+### Generate publish-ready artifact
+
+Run:
+
+```bash
+node scripts/create_publish_ready.js <draft_id> --prepared-by xiangbaqiu
+```
+
+### Record a published result
+
+Run:
+
+```bash
+node scripts/record_publish_result.js <draft_id> --published-by xiangbaqiu --platform-url https://www.xiaohongshu.com/explore/<note_id>
+```
 
 ## Non-goals for this skill
 

--- a/references/project-map.md
+++ b/references/project-map.md
@@ -2,41 +2,62 @@
 
 Project root:
 
-`/Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu`
+`/Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu`
 
 ## Main commands
 
 ### Auto collect multiple accounts
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/auto_collect.js collect.config.json
 ```
 
 ### Generate note draft from a post bundle
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/run_note_pipeline.js note.config.json
 ```
 
 ### Rebuild dashboard data only
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node scripts/build_dashboard_data.js
 ```
 
-### Serve dashboard locally
+### Serve dashboard locally (read-only)
 
 ```bash
-cd /Users/xiangbaqiu/.openclaw/workspace-cto-agent/xiaohongshu-yunying-laizi-x-xingqiu
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 python3 -m http.server 8008
 ```
 
 Open:
 
 `http://127.0.0.1:8008/dashboard/index.html`
+
+### Serve dashboard locally (writable)
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/dashboard_server.js
+```
+
+### Generate publish-ready payload
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/create_publish_ready.js <draft_id> --prepared-by xiangbaqiu
+```
+
+### Record published result
+
+```bash
+cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
+node scripts/record_publish_result.js <draft_id> --published-by xiangbaqiu --platform-url https://www.xiaohongshu.com/explore/<note_id>
+```
 
 ## Important configs
 
@@ -95,11 +116,11 @@ Open:
 }
 ```
 
-### Selection bundle
+### Note bundle
 
 ```json
 {
-  "selection_id": "sel-...",
+  "bundle_id": "bundle-...",
   "theme": "AI coding",
   "bundle_strategy": "one-core-plus-supporting-posts",
   "bundle": {
@@ -137,9 +158,12 @@ Open:
 
 ```json
 {
-  "note_id": "note-...",
+  "draft_id": "draft-...",
+  "brief_id": "brief-...",
+  "bundle_id": "bundle-...",
   "theme": "AI coding",
   "style": "trend-analysis",
+  "review_status": "draft",
   "title_options": ["..."],
   "body_markdown": "...",
   "hashtags": ["#AI"],
@@ -169,11 +193,20 @@ Preferred mode: `replace_latest`
 
 ### Note outputs
 
-- `notes/selections/*.json`
+- `notes/bundles/*.json`
 - `notes/briefs/*.json`
 - `notes/drafts/*.json`
 - `notes/drafts/*.md`
+- `notes/publish-ready/*.json`
+- `notes/publish-records/*.json`
+- `notes/runs/*.json`
 
 ### Dashboard note surface
 
-`data/dashboard/dashboard-data.json` now includes a `notes` array for generated drafts, and the dashboard renders those drafts in the `生成内容` panel.
+`data/dashboard/dashboard-data.json` includes a `notes` array for generated drafts, and the dashboard renders:
+
+- generated draft content
+- explicit `review_status`
+- review annotations
+- publish-ready traceability
+- publish-record traceability


### PR DESCRIPTION
## Summary
- update local workspace paths to the current repo layout
- sync README, SKILL, and references with the bundle/review/publish workflow now shipped in the implementation repo
- document writable dashboard, publish-ready, and publish-record operator commands

## Testing
- no code changes; documentation/runbook sync only

Closes #1