### PR TITLE
docs: add optional TweetClaw intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It defines how an agent should operate the workflow, verify results, and hand of
 
 - Collect one or more X accounts
 - Keep the latest N posts per account with `replace_latest` dedupe
+- Optionally use TweetClaw through OpenClaw to discover candidate X accounts,
+  tweet URLs, reply threads, and monitor topics before editing local configs
 - Rebuild or inspect the local operations dashboard
 - Generate a Xiaohongshu note draft from a bundle of multiple X posts
 - Review drafts inside the writable dashboard
@@ -48,6 +50,26 @@ node src/auto_collect.js collect.config.json
 cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/run_note_pipeline.js note.config.json
 ```
+
+### Optional TweetClaw intake
+
+When the operator needs search-driven X/Twitter inputs before the local
+collector runs, install TweetClaw as a separate OpenClaw plugin:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+Use it to search tweets, search tweet replies, look up users, export follower
+context, monitor tweets, or review webhook events. Treat those results as a
+source-selection step only: pick reviewed handles, tweet URLs, tweet IDs,
+themes, or notes, then update `collect.config.json` and `note.config.json` for
+this skill's existing pipeline.
+
+Keep Xquik credentials in local OpenClaw plugin settings. Do not paste
+credential values, session material, monitor payloads, or private drafts into
+prompts, issues, or public docs. TweetClaw does not replace the dashboard
+review, publish-ready, or publish-record checkpoints in this workflow.
 
 ### Rebuild dashboard
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,7 @@
 
 - 采集一个或多个 X 账号
 - 按 `replace_latest` 模式保留每个账号最新 N 条内容
+- 可选使用 OpenClaw 里的 TweetClaw 插件，先发现候选 X 账号、tweet URL、回复线程和监控主题，再编辑本地配置
 - 重建或检查本地运营 dashboard
 - 基于多条 X 内容生成一篇小红书草稿
 - 在可写 dashboard 中做审核和批注
@@ -46,6 +47,25 @@ node src/auto_collect.js collect.config.json
 cd /Users/catchword/projects/ai/repos/skills/xiaohongshu-yunying-laizi-x-xingqiu
 node src/run_note_pipeline.js note.config.json
 ```
+
+### 可选 TweetClaw 输入筛选
+
+如果运营者需要先用搜索驱动的 X/Twitter 输入，再运行本地采集器，可以把
+TweetClaw 作为独立 OpenClaw 插件安装：
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+用它搜索 tweets、搜索 tweet replies、查询用户、导出 follower context、监控
+tweets，或审核 webhook events。把这些结果只当成 source-selection 步骤：选出
+审核过的 handles、tweet URLs、tweet IDs、themes 或 notes，然后再更新这个
+skill 使用的 `collect.config.json` 和 `note.config.json`。
+
+把 Xquik credentials 保存在本地 OpenClaw plugin settings。不要把 credential
+values、session material、monitor payloads 或 private drafts 粘贴到 prompts、
+issues 或公开文档。TweetClaw 不替代这个工作流里的 dashboard review、
+publish-ready 或 publish-record checkpoints。
 
 ### 重建 dashboard 数据
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -41,6 +41,27 @@ node src/auto_collect.js collect.config.json
    - `state.json` updated
    - dashboard data rebuilt
 
+## Optional source-selection step - TweetClaw
+
+Use this only when the operator needs query-driven X/Twitter source discovery
+before the local collector runs.
+
+Install TweetClaw as a separate OpenClaw plugin:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+Use TweetClaw to search tweets, search tweet replies, look up users, export
+follower context, monitor tweets, or inspect webhook events. Then select
+reviewed handles, tweet URLs, tweet IDs, themes, or notes and put them into the
+existing `collect.config.json` and `note.config.json` flow.
+
+Keep Xquik credentials in local OpenClaw plugin settings. Do not paste
+credential values, session material, monitor payloads, or private drafts into
+prompts, issues, or public docs. TweetClaw does not replace the dashboard
+review, publish-ready, or publish-record checkpoints.
+
 ## Command 2 — Verify collection
 
 Goal: confirm the collector met the requested target.


### PR DESCRIPTION
## Summary

- Add an optional TweetClaw intake step to the English README, Chinese README, and SKILL runbook.
- Keep the existing xiaohongshu-x-planet collector, dashboard review, publish-ready, and publish-record flow as the source of truth.
- Frame TweetClaw as a source-selection helper for reviewed X/Twitter handles, tweet URLs, tweet IDs, themes, and notes before updating local configs.

## Review Notes

- TweetClaw is installed as a separate OpenClaw plugin with `openclaw plugins install npm:@xquik/tweetclaw`.
- The new guidance keeps credentials in local OpenClaw plugin settings and uses generic credential wording in public docs.
- No readiness badge was added because the target has no existing badge area where an xquik.com badge would help readers evaluate one optional intake step.

## Validation

- Read README.md, README.zh-CN.md, SKILL.md, references/project-map.md, references/ops-rules.md, MIT license, repo metadata, issue history, PR history, and local content.
- Duplicate checks found no existing TweetClaw, Xquik, ClawHub, or x-twitter-scraper issue, PR, audit entry, or local content before this PR.
- `git diff --check`
- Added-line scans for conflict markers, sensitive values, stale private names, and dash hygiene
- Local Markdown link check across README.md, README.zh-CN.md, SKILL.md, and references
- Public link check: target repo 200, implementation repo 200, TweetClaw repo 200; localhost dashboard and placeholder Xiaohongshu note URL skipped as examples
- SKILL frontmatter presence check
- `npm view @xquik/tweetclaw version openclaw.install --json` returned version 1.6.31 and npm install metadata